### PR TITLE
Add fourth set of core filters

### DIFF
--- a/package/docs/filters/1. array.md
+++ b/package/docs/filters/1. array.md
@@ -3,6 +3,36 @@ title: Arrays
 tags: Template helpers
 ---
 
+## formatList
+
+Convert array to a list formatted as a sentence.
+
+Input
+
+```njk
+{{ ["England", "Scotland", "Wales"] | formatList }}
+```
+
+Output
+
+```html
+England, Scotland and Wales
+```
+
+To format the list using a disjunction:
+
+Input
+
+```njk
+{{ ["England", "Scotland", "Wales"] | formatList("disjunction") }}
+```
+
+Output
+
+```html
+England, Scotland or Wales
+```
+
 ## isArray
 
 Checks if a value is classified as an [`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) object.
@@ -19,4 +49,54 @@ Output
 ```html
 true
 false
+```
+
+## rejectFromArray
+
+Reject items in an array that have a key with a given value.
+
+Input
+
+```njk
+{{ [{
+  name: "Sally Smith"
+  role: "admin"
+}, {
+  name: "David Jones"
+  role: "user"
+}] | rejectFromArray("role", "admin") | dump }}
+```
+
+Output
+
+```html
+[{
+  name: "David Jones"
+  role: "user"
+}]
+```
+
+## selectFromArray
+
+Select items in an array that have a key with a given value.
+
+Input
+
+```njk
+{{ [{
+  name: "Sally Smith"
+  role: "admin"
+}, {
+  name: "David Jones"
+  role: "user"
+}] | selectFromArray("role", "admin") | dump }}
+```
+
+Output
+
+```html
+[{
+  name: "Sally Smith"
+  role: "admin"
+}]
 ```

--- a/package/docs/filters/4. object.md
+++ b/package/docs/filters/4. object.md
@@ -22,3 +22,27 @@ true
 true
 false
 ```
+
+## objectToArray
+
+Transforms an object to an array, using each object’s key as the value for `id`.
+
+Input
+
+```njk
+{{ {
+  "a": { name: "Sir Robert Walpole" },
+  "b": { name: "Spencer Compton" },
+  "c": { name: "Henry Pelham" },
+} | objectToArray | dump }}
+```
+
+Output
+
+```html
+[
+  { id: "a", name: "Sir Robert Walpole" },
+  { id: "b", name: "Spencer Compton" },
+  { id: "c", name: "Henry Pelham" },
+]
+```

--- a/package/rig/filters/array.js
+++ b/package/rig/filters/array.js
@@ -2,7 +2,32 @@ import _ from 'lodash'
 import { _normalize } from '../../lib/nunjucks.js'
 
 /**
- * Checks if `value` is classified as an `Array` object.
+ * Convert array to a list formatted as a sentence.
+ *
+ * @example
+ * formatList(['England', 'Scotland', 'Wales'])
+ * // England, Scotland and Wales
+ *
+ * @example
+ * formatList(['England', 'Scotland', 'Wales'], 'disjunction')
+ * // England, Scotland or Wales
+ *
+ * @param {Array} array - Array to convert
+ * @param {string} [type=conjunction] - Format of output
+ * @returns {string} Formatted list
+ */
+export function formatList (array, type = 'conjunction') {
+  array = _normalize(array, '')
+
+  const listFormat = new Intl.ListFormat('en-GB', {
+    style: 'long',
+    type
+  })
+  return listFormat.format(array)
+}
+
+/**
+ * Check if `value` is classified as an `Array` object.
  *
  * @example
  * isArray(['england', 'scotland', 'wales']) // true
@@ -19,6 +44,61 @@ export function isArray (value) {
   return _.isArray(value)
 }
 
+/**
+ * Reject items in an array that have a key with a given value.
+ *
+ * @example
+ * rejectFromArray([{
+ *   name: 'Sally Smith'
+ *   role: 'admin'
+ * }, {
+ *   name: 'David Jones'
+ *   role: 'user'
+ * }], 'role', 'admin')
+ *
+ * // [{
+ * //  name: 'David Jones'
+ * //  role: 'user'
+ * // }]
+ *
+ * @param {Array} array - Array to filter
+ * @param {string} key - Key to filter on
+ * @param {string} value - Value to filter by
+ * @returns Filtered array
+ */
+export function rejectFromArray (array, key, value) {
+  return array.filter(item => !value.includes(_.get(item, key)))
+}
+
+/**
+ * Select items in an array that have a key with a given value.
+ *
+ * @example
+ * selectFromArray([{
+ *   name: 'Sally Smith'
+ *   role: 'admin'
+ * }, {
+ *   name: 'David Jones'
+ *   role: 'user'
+ * }], 'role', 'admin')
+ *
+ * // [{
+ * //  name: 'Sally Smith'
+ * //  role: 'admin'
+ * // }]
+ *
+ * @param {Array} array - Array to filter
+ * @param {string} key - Key to filter on
+ * @param {string} value - Value to filter by
+ * @returns Filtered array
+ */
+export function selectFromArray (array, key, value) {
+  return array.filter(item => value.includes(_.get(item, key)))
+}
+
 export const arrayFilters = {
-  isArray
+  formatList,
+  isArray,
+  rejectFromArray,
+  selectFromArray
 }

--- a/package/rig/filters/number.js
+++ b/package/rig/filters/number.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import { _normalize } from '../../lib/nunjucks.js'
 
 /**
- * Checks if `value` is classified as a `Number` primitive or object.
+ * Check if `value` is classified as a `Number` primitive or object.
  *
  * @example
  * isNumber(1801) // true

--- a/package/rig/filters/object.js
+++ b/package/rig/filters/object.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import { _normalize } from '../../lib/nunjucks.js'
 
 /**
- * Checks if `value` is the language type of `Object`.
+ * Check if `value` is the language type of `Object`.
  *
  * @example
  * isObject({country: 'england'}) // true
@@ -22,6 +22,36 @@ export function isObject (value) {
   return _.isObject(value)
 }
 
+/**
+ * Transform object to an array, using key name as value for id.
+ *
+ * @example
+ * objectToArray({
+ *   1: { name: 'Sir Robert Walpole' },
+ *   2: { name: 'Spencer Compton' },
+ *   3: { name: 'Henry Pelham' },
+ * })
+ *
+ * // [
+ * //   { id: 1, name: 'Sir Robert Walpole' },
+ * //   { id: 2, name: 'Spencer Compton' },
+ * //   { id: 3, name: 'Henry Pelham' },
+ * // ]
+ *
+ * @param {Object} object - Object to transform
+ * @returns
+ */
+export function objectToArray (object) {
+  const objectArray = []
+  Object.keys(object).forEach(key => objectArray.push({
+    ...{ id: key },
+    ...object[key]
+  }))
+
+  return objectArray
+}
+
 export const objectFilters = {
-  isObject
+  isObject,
+  objectToArray
 }

--- a/package/rig/filters/string.js
+++ b/package/rig/filters/string.js
@@ -22,7 +22,7 @@ export function govukMarkdown (string, options) {
 }
 
 /**
- * Checks if `value` is classified as a `String` primitive or object.
+ * Check if `value` is classified as a `String` primitive or object.
  *
  * @example
  * isString('Number 10') // true
@@ -80,7 +80,7 @@ export function slugify (string) {
 }
 
 /**
- * Checks if `string` starts with `value`.
+ * Check if `string` starts with `value`.
  *
  * @example
  * startsWith('Department of Transport', 'Department') // true


### PR DESCRIPTION
Adds fourth set of core filters that are provided by the Prototype Rig by default. These focus on some common transformations for objects and arrays.

## Array

* `formatList`: Convert array to a list formatted as a sentence. [Review documentation](https://govuk-protot-core-filte-r9mwbb.herokuapp.com/docs/filters/array#formatlist)

* `rejectFromArray`: Reject items in an array that have a key with a given value. [Review documentation](https://govuk-protot-core-filte-r9mwbb.herokuapp.com/docs/filters/array#rejectfromarray)

* `selectFromArray`: Select items in an array that have a key with a given value. [Review documentation](https://govuk-protot-core-filte-r9mwbb.herokuapp.com/docs/filters/array#selectfromarray)

## Object

* `objectToArray`: Transform object to an array, using key name as value for id. [Review documentation](https://govuk-protot-core-filte-r9mwbb.herokuapp.com/docs/filters/object#objecttoarray)