### PR TITLE
Experiments in making .njk and .html work

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,6 @@
 {
   "name": "Your service name",
+  "defaultFileExtension": "html",
   "env": {
     "USE_AUTH": {
       "description": "Enable or disable password protection on production.",

--- a/package/lib/server.js
+++ b/package/lib/server.js
@@ -53,8 +53,13 @@ if (isSecure) {
 app.use(authentication)
 
 // Set views engine
-app.engine('njk', getNunjucksEnv(app, env).render)
-app.set('view engine', 'njk')
+const defaultFileExtension = appJson.defaultFileExtension || 'njk'
+const nunjucks = getNunjucksEnv(app, env).render
+app.engine(defaultFileExtension, nunjucks)
+if (defaultFileExtension !== 'njk') {
+  app.engine('njk', nunjucks)
+}
+app.set('view engine', defaultFileExtension)
 
 // Serve static assets
 app.use('/public', express.static('./public'))


### PR DESCRIPTION
Using the `.njk` file extension is fairly uncommon.

I've looked at trying to provide a way of making it customisable.

But I think we should default to `.html`

Switching a prototype to rig without this will be more difficult.