### PR TITLE
Add package configuration options

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,4 @@
 {
-  "name": "Your service name",
   "env": {
     "USE_AUTH": {
       "description": "Enable or disable password protection on production.",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
   "engines": {
     "node": ">=16.0.0"
   },
+  "prototype": {
+    "serviceName": "Your service name",
+    "templateExtension": "njk"
+  },
+  "stylelint": {
+    "extends": "stylelint-config-gds/scss"
+  },
   "scripts": {
     "build-assets": "rollup --config --silent",
     "watch-assets": "rollup --config --silent --watch",
@@ -29,8 +36,5 @@
     "standard": "^16.0.4",
     "stylelint": "^13.13.1",
     "stylelint-config-gds": "^0.1.0"
-  },
-  "stylelint": {
-    "extends": "stylelint-config-gds/scss"
   }
 }

--- a/package/lib/config.js
+++ b/package/lib/config.js
@@ -1,0 +1,11 @@
+import { cosmiconfig } from 'cosmiconfig'
+
+const explorer = cosmiconfig('govuk-prototype-rig', {
+  packageProp: 'prototype'
+})
+
+export async function getConfig () {
+  const search = await explorer.search()
+  const result = await search
+  return result.config
+}


### PR DESCRIPTION
Partly fixes #25, and in service of #12.

As the prototype components get hidden away in a package, so there is a need for certain aspects to be configurable. This PR adds the ability to explicitly configure the `serviceName` (rather than rely on `app.json` whose purpose is the configuration of Heroku applications) and a `templateExtension`. This is set to `njk`, but the default if no value is given is `html`. A subsequent PR can change the example page layouts to use `.html`.