### PR TITLE
Refactor config

### DIFF
--- a/package/lib/config.js
+++ b/package/lib/config.js
@@ -1,11 +1,43 @@
+import dotenv from 'dotenv'
 import { cosmiconfig } from 'cosmiconfig'
 
-const explorer = cosmiconfig('govuk-prototype-rig', {
-  packageProp: 'prototype'
-})
+dotenv.config()
 
-export async function getConfig () {
+const defaultConfig = {
+  promoMode: false,
+  serviceName: 'Your service name',
+  templateExtension: 'html',
+  useAuth: false,
+  useAutoStoreData: true,
+  useCookieSessionStore: false,
+  useHttps: false
+}
+
+/**
+ * Get user config values from package.json or config file.
+ *
+ * @see {@link https://github.com/davidtheclark/cosmiconfig#readme}
+ *
+ * @access private
+ * @returns {Object} User config
+ */
+async function _getUserConfig () {
+  const explorer = cosmiconfig('govuk-prototype-rig', {
+    packageProp: 'prototype'
+  })
+
   const search = await explorer.search()
   const result = await search
   return result.config
+}
+
+/**
+ * Get config derived from user and default config values.
+ *
+ * @returns {Object} Combined config
+ */
+export async function getConfig () {
+  const userConfig = await _getUserConfig()
+
+  return { ...defaultConfig, ...userConfig }
 }

--- a/package/lib/environment.js
+++ b/package/lib/environment.js
@@ -1,9 +1,11 @@
 import fs from 'node:fs'
+import _ from 'lodash'
 import inquirer from 'inquirer'
 import portScanner from 'portscanner'
 
 /**
- * Get environment variable as a Boolean value.
+ * Get environment variable as a Boolean value, defaulting to value
+ * in configuration.
  *
  * @example "true" => true
  * @example "TRUE" => true
@@ -11,22 +13,18 @@ import portScanner from 'portscanner'
  * @example "foo" => false
  *
  * @param {Object|Array} name - Name of variable
- * @param {string|Array} [appJson=false] - App manifest
+ * @param {Object} config - Package configuration
  * @returns {boolean} Returns `true` if `name` evaluates to true
  */
-export const getEnvBoolean = (name, appJson = false) => {
-  let envName
-  if (appJson) {
-    envName = process.env[name] || appJson.env[name].value
+export const getEnvBoolean = (name, config) => {
+  let value
+  if (config) {
+    value = process.env[name] || config[_.camelCase(name)]
   } else {
-    envName = process.env[name]
+    value = process.env[name]
   }
 
-  if (!envName) {
-    return
-  }
-
-  return envName.toLowerCase() === 'true'
+  return String(value).toLowerCase() === 'true'
 }
 
 /**

--- a/package/lib/middleware/authentication.js
+++ b/package/lib/middleware/authentication.js
@@ -9,22 +9,19 @@ import basicAuth from 'basic-auth'
  * @returns {Function} Express middleware requiring the given credentials
  */
 export function authentication (req, res, next) {
-  const { env, useAuth } = res.app.locals
   const username = process.env.USERNAME
   const password = process.env.PASSWORD
 
-  if (env === 'production' && useAuth) {
-    if (!username || !password) {
-      console.error('Username or password is not set')
-      return res.send('Username or password is not set')
-    }
+  if (!username || !password) {
+    console.error('Username or password is not set')
+    return res.send('Username or password is not set')
+  }
 
-    const user = basicAuth(req)
+  const user = basicAuth(req)
 
-    if (!user || user.name !== username || user.pass !== password) {
-      res.set('WWW-Authenticate', 'Basic realm=Authorization Required')
-      return res.sendStatus(401)
-    }
+  if (!user || user.name !== username || user.pass !== password) {
+    res.set('WWW-Authenticate', 'Basic realm=Authorization Required')
+    return res.sendStatus(401)
   }
 
   next()

--- a/package/lib/server.js
+++ b/package/lib/server.js
@@ -28,6 +28,8 @@ const { serviceName } = config
 const templateExtension = config.templateExtension || 'html'
 const glitchEnv = process.env.PROJECT_REMIX_CHAIN ? 'production' : false // glitch.com
 const env = process.env.NODE_ENV || glitchEnv || 'development'
+const isProduction = env === 'production'
+
 const promoMode = getEnvBoolean('PROMO_MODE')
 const useAuth = getEnvBoolean('USE_AUTH', appJson)
 const useAutoStoreData = getEnvBoolean('USE_AUTO_STORE_DATA', appJson)
@@ -45,15 +47,15 @@ app.locals.useAutoStoreData = useAutoStoreData
 app.locals.useCookieSessionStore = useCookieSessionStore
 
 // Force HTTPS on production. Do this before using basicAuth to avoid
-// asking for username/password twice (for `http`, then `https`).
-const isSecure = (env === 'production' && useHttps)
+// asking for username/password twice (for `http`, then `https`)
+const isSecure = (isProduction && useHttps)
 if (isSecure) {
   app.use(forceHttps)
   app.set('trust proxy', 1) // Needed for secure cookies on Heroku
 }
 
 // Authentication
-if (env === 'production' && useAuth) {
+if (isProduction && useAuth) {
   app.use(authentication)
 }
 
@@ -199,7 +201,7 @@ app.use((error, req, res, next) => {
 })
 
 findAvailablePort(app, (port) => {
-  if (process.env.NODE_ENV === 'production') {
+  if (isProduction) {
     console.info(`Listening on port ${port}`)
     app.listen(port)
   } else {

--- a/package/lib/server.js
+++ b/package/lib/server.js
@@ -52,8 +52,10 @@ if (isSecure) {
   app.set('trust proxy', 1) // Needed for secure cookies on Heroku
 }
 
-// Authentication middleware
-app.use(authentication)
+// Authentication
+if (env === 'production' && useAuth) {
+  app.use(authentication)
+}
 
 // Set views engine
 app.engine(templateExtension, getNunjucksEnv(app, env).render)


### PR DESCRIPTION
Another PR in support of #12.

Placing user config in `app.json`, which is intended for Heroku application deployment, isn’t the right approach. It has it’s own schema, which we’d need to break if we were to add custom values. It also shouldn’t be a requirement for setting up a prototype rig. (This is why in #26 we moved prototype config into `package.json` – although Cosmic Config allows config to be in any number of conventional locations).

This PR refactors how we load in config. Configuration is now managed in `lib/config.js`. In here, we provide a set of defaults (5 of which can be overridden with environment variables), and merge this with any user configuration values.

The order of priority should be:

1. Value in environment variable (if applicable)
2. Value in user configuration (i.e. those in `package.json`)
3. Value in default configuration