### PR TITLE
Remove relative paths in package files

### DIFF
--- a/package/lib/middleware/auto-store-data.js
+++ b/package/lib/middleware/auto-store-data.js
@@ -51,7 +51,7 @@ const _storeData = (input, data) => {
 export async function autoStoreData (req, res, next) {
   // Get session default data from file
   let sessionDataDefaults = {}
-  const sessionDataDefaultsFile = new URL('../../../app/data.js', import.meta.url).pathname
+  const sessionDataDefaultsFile = `${process.cwd()}/app/data.js`
 
   try {
     sessionDataDefaults = await import(sessionDataDefaultsFile)

--- a/package/lib/nunjucks.js
+++ b/package/lib/nunjucks.js
@@ -1,5 +1,4 @@
 import fs from 'node:fs'
-import { fileURLToPath } from 'node:url'
 import nunjucks from 'nunjucks'
 
 import { arrayFilters } from '../rig/filters/array.js'
@@ -48,7 +47,7 @@ async function _addFilters (nunjucksAppEnv) {
 
   // Add any app filters to Nunjucks environment
   // App filters can access package filters using env.getFilter()
-  const appFiltersPath = fileURLToPath(new URL('../../app/filters.js', import.meta.url))
+  const appFiltersPath = `${process.cwd()}/app/filters.js`
 
   let appFilters
   if (fs.existsSync(appFiltersPath)) {
@@ -68,7 +67,7 @@ async function _addFilters (nunjucksAppEnv) {
  * @param {Object} nunjucksAppEnv - Nunjucks environment
  */
 async function _addGlobals (nunjucksAppEnv) {
-  const appGlobalsPath = fileURLToPath(new URL('../../app/globals.js', import.meta.url))
+  const appGlobalsPath = `${process.cwd()}/app/globals.js`
 
   let appGlobals
   if (fs.existsSync(appGlobalsPath)) {

--- a/package/lib/server.js
+++ b/package/lib/server.js
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import express from 'express'
 import sessionInCookie from 'client-sessions'
 import sessionInMemory from 'express-session'
@@ -13,7 +14,6 @@ import { browserSyncConfig } from './browser-sync.js'
 import { findAvailablePort, getEnvBoolean } from './environment.js'
 import { getConfig } from './config.js'
 import { getNunjucksEnv } from './nunjucks.js'
-import routes from '../../app/routes.js'
 
 // Environment
 const glitchEnv = process.env.PROJECT_REMIX_CHAIN ? 'production' : false // glitch.com
@@ -121,8 +121,12 @@ if (promoMode) {
   app.get('/', (req, res) => res.redirect('/docs'))
 }
 
-// Load routes (found in app/routes.js)
-app.use('/', routes)
+// Load routes
+const appRoutesPath = `${process.cwd()}/app/routes.js`
+if (fs.existsSync(appRoutesPath)) {
+  const appRoutes = await import(appRoutesPath)
+  app.use('/', appRoutes.default)
+}
 
 // Strip .html and .htm if provided
 app.get(/\.html?$/i, (req, res) => {


### PR DESCRIPTION
Another PR in support of #12.

Using relative paths isn’t a reliable method of resolving paths to files in the `./app` directory. This removes relative paths (i.e. `../../app/`) and uses `process.cwd()` instead.