### PR TITLE
Fix the loading of globals in 'app/globals.js'

### DIFF
--- a/packages/govuk-prototype-rig/lib/nunjucks.js
+++ b/packages/govuk-prototype-rig/lib/nunjucks.js
@@ -66,7 +66,7 @@ async function _addGlobals (nunjucksAppEnv) {
   }
 
   for (const globalName of Object.keys(appGlobals)) {
-    nunjucksAppEnv.addGlobal(global, appGlobals[globalName])
+    nunjucksAppEnv.addGlobal(globalName, appGlobals[globalName])
   }
 }
 


### PR DESCRIPTION
Before this change, the global functions defined in the prototype folder weren't being registered correctly.