### PR TITLE
Allow form controls to be decorated with a parameter

### DIFF
--- a/app/views/examples/autocomplete.html
+++ b/app/views/examples/autocomplete.html
@@ -6,7 +6,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form method="post" novalidate>
-        {{ xGovukAutocomplete(decorate({
+        {{ xGovukAutocomplete({
           allowEmpty: false,
           label: {
             classes: "govuk-label--l",
@@ -65,8 +65,9 @@
             { text: "West Yorkshire" },
             { text: "Wiltshire" },
             { text: "Worcestershire" }
-          ]
-        }, "county")) }}
+          ],
+          decorate: "county"
+        }) }}
 
         {{ govukButton({
           text: "Continue"

--- a/app/views/examples/question.html
+++ b/app/views/examples/question.html
@@ -7,7 +7,6 @@
     <div class="govuk-grid-column-two-thirds">
       <form method="post" novalidate>
         {{ govukDateInput({
-          decorate: "passport-issued",
           fieldset: {
             legend: {
               classes: "govuk-fieldset__legend--l",
@@ -17,7 +16,8 @@
           },
           hint: {
             text: "For example, 27 3 2007"
-          }
+          },
+          decorate: "passport-issued"
         }) }}
 
         {{ govukButton({

--- a/app/views/examples/question.html
+++ b/app/views/examples/question.html
@@ -6,7 +6,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form method="post" novalidate>
-        {{ govukDateInput(decorate({
+        {{ govukDateInput({
+          decorate: "passport-issued",
           fieldset: {
             legend: {
               classes: "govuk-fieldset__legend--l",
@@ -16,15 +17,8 @@
           },
           hint: {
             text: "For example, 27 3 2007"
-          },
-          items: [{
-            decorate: "day"
-          }, {
-            decorate: "month"
-          }, {
-            decorate: "year"
-          }]
-        }, "passport-issued")) }}
+          }
+        }) }}
 
         {{ govukButton({
           text: "Continue"

--- a/app/views/examples/validation-errors.html
+++ b/app/views/examples/validation-errors.html
@@ -8,26 +8,28 @@
       <form method="post" novalidate data-validate>
         <h1 class="govuk-heading-l">Personal details</h1>
 
-        {{ govukInput(decorate({
+        {{ govukInput({
           label: {
             text: "Full name"
           },
           autocomplete: "name",
           spellcheck: false,
+          decorate: ["account", "full-name"],
           validate: {
             presence: {
               message: "Enter your full name"
             }
           }
-        }, ["account", "full-name"])) }}
+        }) }}
 
-        {{ govukInput(decorate({
+        {{ govukInput({
           label: {
             text: "Email address"
           },
           autocomplete: "email",
           spellcheck: false,
           type: "email",
+          decorate: ["account", "email"],
           validate: {
             presence: {
               message: "Enter your email address"
@@ -36,7 +38,7 @@
               message: "Enter an email address in the correct format, like name@example.com"
             }
           }
-        }, ["account", "email"])) }}
+        }) }}
 
         {{ govukButton({
           text: "Continue"

--- a/app/views/examples/validation-examples.html
+++ b/app/views/examples/validation-examples.html
@@ -9,21 +9,22 @@
         <h1 class="govuk-heading-l">{{ title }}</h1>
 
         <h2 class="govuk-heading-m">Text input</h2>
-        {{ govukInput(decorate({
+        {{ govukInput({
           label: {
             text: "Full name"
           },
           autocomplete: "name",
           spellcheck: false,
+          decorate: "full-name",
           validate: {
             presence: {
               message: "Enter your full name"
             }
           }
-        }, ["full-name"])) }}
+        }) }}
 
         <h2 class="govuk-heading-m">Radio buttons</h2>
-        {{ govukRadios(decorate({
+        {{ govukRadios({
           classes: "govuk-radios--inline",
           fieldset: {
             legend: {
@@ -40,15 +41,16 @@
             value: "no",
             text: "No"
           }],
+          decorate: "changed-name",
           validate: {
             presence: {
               message: "Select if you have changed your name"
             }
           }
-        }, ["changed-name"])) }}
+        }) }}
 
         <h2 class="govuk-heading-m">Checkboxes</h2>
-        {{ govukCheckboxes(decorate({
+        {{ govukCheckboxes({
           fieldset: {
             legend: {
               text: "Which types of waste do you transport?"
@@ -67,30 +69,32 @@
             value: "farm",
             text: "Farm or agricultural waste"
           }],
+          decorate: "waste",
           validate: {
             presence: {
               message: "Select a type of waste"
             }
           }
-        }, ["waste"])) }}
+        }) }}
 
         <h2 class="govuk-heading-m">Textarea</h2>
-        {{ govukTextarea(decorate({
+        {{ govukTextarea({
           label: {
             text: "Can you provide more detail?"
           },
           hint: {
             text: "Do not include personal or financial information, like your National Insurance number or credit card details."
           },
+          decorate: "more-detail",
           validate: {
             presence: {
               message: "Enter more details"
             }
           }
-        }, ["more-detail"])) }}
+        }) }}
 
         <h2 class="govuk-heading-m">Date input</h2>
-        {{ govukDateInput(decorate({
+        {{ govukDateInput({
           fieldset: {
             legend: {
               text: "When was your passport issued?"
@@ -99,13 +103,7 @@
           hint: {
             text: "For example, 12 11 2007"
           },
-          items: [{
-            decorate: "day"
-          }, {
-            decorate: "month"
-          }, {
-            decorate: "year"
-          }],
+          decorate: "passport-issued",
           validate: {
             presence: {
               message: "Enter the date your passport was issued"
@@ -114,10 +112,10 @@
               message: "Passport issued should be a valid date"
             }
           }
-        }, ["passport-issued"])) }}
+        }) }}
 
         <h2 class="govuk-heading-m">Select</h2>
-        {{ govukSelect(decorate({
+        {{ govukSelect({
           label: {
             text: "Sort by"
           },
@@ -138,12 +136,13 @@
             value: "comments",
             text: "Most comments"
           }],
+          decorate: "sort",
           validate: {
             presence: {
               message: "Select a sort method"
             }
           }
-        }, ["sort"])) }}
+        }) }}
 
         <h2 class="govuk-heading-m">Fieldset</h2>
         {% call govukFieldset({
@@ -152,56 +151,44 @@
             text: "What is your address?"
           }
         }) %}
-          {{ govukInput(decorate({
+          {{ govukInput({
             label: {
               html: "Building and street <span class=\"govuk-visually-hidden\">line 1 of 2</span>"
-            }
-          }, ["address-line-1"])) }}
+            },
+            decorate: "address-line-1"
+          }) }}
 
-          {{ govukInput(decorate({
+          {{ govukInput({
             label: {
               html: "<span class=\"govuk-visually-hidden\">Building and street line 2 of 2</span>"
-            }
-          }, ["address-line-2"])) }}
+            },
+            decorate: "address-line-2"
+          }) }}
 
-          {{ govukInput(decorate({
+          {{ govukInput({
             classes: "govuk-!-width-two-thirds",
             label: {
               text: "Town or city"
-            }
-          }, ["address-town"])) }}
-
-          {{ govukInput(decorate({
-            classes: "govuk-!-width-two-thirds",
-            label: {
-              text: "County"
             },
-            validate: {
-              presence: {
-                message: "Enter your county"
-              },
-              length: {
-                minimum: 3,
-                tooShort: "Enter a real county name"
-              }
-            }
-          }, ["address-county"])) }}
+            decorate: "address-town"
+          }) }}
 
-          {{ govukInput(decorate({
+          {{ govukInput({
             classes: "govuk-input--width-10",
             label: {
               text: "Postcode"
             },
+            decorate: "address-postcode",
             validate: {
               presence: {
                 message: "Enter your postcode"
               }
             }
-          }, ["address-postcode"])) }}
+          }) }}
         {% endcall %}
 
         <h2 class="govuk-heading-m">Conditional answers</h2>
-        {{ govukRadios(decorate({
+        {{ govukRadios({
           fieldset: {
             legend: {
               classes: "govuk-fieldset__legend--s",
@@ -215,13 +202,14 @@
             value: "email",
             text: "Email",
             conditional: {
-              html: govukInput(decorate({
+              html: govukInput({
                 classes: "govuk-!-width-one-third",
                 label: {
                   text: "Email address"
                 },
                 type: "email",
                 spellcheck: "false",
+                decorate: "contact-by-email",
                 validate: {
                   conditional: {
                     dependentOn: {
@@ -231,18 +219,19 @@
                     message: "Please enter your email address"
                   }
                 }
-              }, ["contact-by-email"]))
+              })
             }
           }, {
             value: "phone",
             text: "Phone",
             conditional: {
-              html: govukInput(decorate({
+              html: govukInput({
                 classes: "govuk-!-width-one-third",
                 label: {
                   text: "Phone number"
                 },
                 type: "tel",
+                decorate: "contact-by-phone",
                 validate: {
                   conditional: {
                     dependentOn: {
@@ -252,18 +241,19 @@
                     message: "Please enter your phone number"
                   }
                 }
-              }, ["contact-by-phone"]))
+              })
             }
           }, {
             value: "sms",
             text: "Text message",
             conditional: {
-              html: govukInput(decorate({
+              html: govukInput({
                 classes: "govuk-!-width-one-third",
                 label: {
                   text: "Mobile phone number"
                 },
                 type: "tel",
+                decorate: "contact-by-sms",
                 validate: {
                   conditional: {
                     dependentOn: {
@@ -273,15 +263,16 @@
                     message: "Please enter your mobile phone number"
                   }
                 }
-              }, ["contact-by-sms"]))
+              })
             }
           }],
+          decorate: "how-contacted",
           validate: {
             presence: {
               message: "Select a contact method"
             }
           }
-        }, ["how-contacted"])) }}
+        }) }}
 
         {{ govukButton({
           text: "Continue"

--- a/app/views/examples/wizard/england.html
+++ b/app/views/examples/wizard/england.html
@@ -12,7 +12,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form method="post" action="{{ paths.current }}" novalidate>
-        {{ govukRadios(decorate({
+        {{ govukRadios({
           fieldset: {
             legend: {
               classes: "govuk-fieldset__legend--l",
@@ -24,8 +24,9 @@
             text: "Yes, I’ve always lived in England"
           }, {
             text: "No, I have lived somewhere else too"
-          }]
-        }, ["wizard", "always-england"])) }}
+          }],
+          decorate: ["wizard", "always-england"]
+        }) }}
 
         {{ govukButton({
           html: "Continue"

--- a/app/views/examples/wizard/name.html
+++ b/app/views/examples/wizard/name.html
@@ -12,13 +12,14 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form method="post" action="{{ paths.current }}" novalidate>
-        {{ govukInput(decorate({
+        {{ govukInput({
           label: {
             classes: "govuk-label--l",
             isPageHeading: true,
             text: title
-          }
-        }, ["wizard", "name"])) }}
+          },
+          decorate: ["wizard", "name"]
+        }) }}
 
         {{ govukButton({
           html: "Continue"

--- a/app/views/examples/wizard/nationality.html
+++ b/app/views/examples/wizard/nationality.html
@@ -12,7 +12,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form method="post" action="{{ paths.current }}" novalidate>
-        {{ govukCheckboxes(decorate({
+        {{ govukCheckboxes({
           fieldset: {
             legend: {
               classes: "govuk-fieldset__legend--l",
@@ -33,8 +33,9 @@
           }, {
             value: "other",
             text: "Citizen of another country"
-          }]
-        }, ["wizard", "nationality"]) ) }}
+          }],
+          decorate: ["wizard", "nationality"]
+        }) }}
 
         {{ govukButton({
           html: "Continue"

--- a/app/views/examples/wizard/where-do-you-live.html
+++ b/app/views/examples/wizard/where-do-you-live.html
@@ -12,7 +12,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form method="post" action="{{ paths.current }}" novalidate>
-        {{ govukRadios(decorate({
+        {{ govukRadios({
           fieldset: {
             legend: {
               classes: "govuk-fieldset__legend--l",
@@ -28,8 +28,9 @@
             text: "Wales"
           }, {
             text: "Northern Ireland"
-          }]
-        }, ["wizard", "where-do-you-live"])) }}
+          }],
+          decorate: ["wizard", "where-do-you-live"]
+        }) }}
 
         {{ govukButton({
           html: "Continue"

--- a/packages/govuk-prototype-components/lib/decorate.js
+++ b/packages/govuk-prototype-components/lib/decorate.js
@@ -1,46 +1,6 @@
 import _ from 'lodash'
 
 /**
- * Check if a property value exists.
- *
- * Note: You do not need to use this helper if you are using the
- * `decorate` helper.
- *
- * @param {string} keyPath - Path to key (using dot/bracket notation)
- * @param {string} value - Value to check
- * @returns {boolean} Returns `true` if `value` exists, else `false`
- */
-export function checked (keyPath, value) {
-  keyPath = _.toPath(keyPath)
-
-  const { data } = this.ctx
-  if (!data) {
-    return ''
-  }
-
-  const storedValue = data[keyPath]
-  if (!storedValue) {
-    return ''
-  }
-
-  let checkedValue = ''
-
-  if (Array.isArray(storedValue)) {
-    // Stored value is an array, check it exists in the array
-    if (storedValue.indexOf(value) !== -1) {
-      checkedValue = 'checked'
-    }
-  } else {
-    // Stored value is a simple value, check it matches
-    if (storedValue === value) {
-      checkedValue = 'checked'
-    }
-  }
-
-  return checkedValue
-}
-
-/**
  * Add `name`, `value`, `id`, `idPrefix` and `checked`/`selected` attributes
  * to GOV.UK form inputs. Generates attributes based on where they are stored
  * in the session data object.
@@ -178,9 +138,4 @@ export function decorate (params, keyPath, componentName) {
   }
 
   return params
-}
-
-export const helperGlobals = {
-  checked,
-  decorate
 }

--- a/packages/govuk-prototype-components/package.json
+++ b/packages/govuk-prototype-components/package.json
@@ -12,6 +12,9 @@
   "exports": {
     ".": {
       "import": "./x-govuk/all.js"
+    },
+    "./decorate": {
+      "import": "./lib/decorate.js"
     }
   },
   "repository": {

--- a/packages/govuk-prototype-components/x-govuk/components/autocomplete/template.njk
+++ b/packages/govuk-prototype-components/x-govuk/components/autocomplete/template.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
+{% set params = decorate(params, params.decorate) %}
 
 {# Only select the first item if a value hasn’t already been given #}
 {% set selectFirstItem = true %}

--- a/packages/govuk-prototype-components/x-govuk/components/decorated/checkboxes/macro.njk
+++ b/packages/govuk-prototype-components/x-govuk/components/decorated/checkboxes/macro.njk
@@ -1,0 +1,4 @@
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes as source %}
+{% macro govukCheckboxes(params) %}
+  {{ source(decorate(params, params.decorate)) }}
+{% endmacro %}

--- a/packages/govuk-prototype-components/x-govuk/components/decorated/date-input/macro.njk
+++ b/packages/govuk-prototype-components/x-govuk/components/decorated/date-input/macro.njk
@@ -1,4 +1,4 @@
 {% from "govuk/components/date-input/macro.njk" import govukDateInput as source %}
 {% macro govukDateInput(params) %}
-  {{ source(decorate(params, params.decorate)) }}
+  {{ source(decorate(params, params.decorate, 'govukDateInput')) }}
 {% endmacro %}

--- a/packages/govuk-prototype-components/x-govuk/components/decorated/date-input/macro.njk
+++ b/packages/govuk-prototype-components/x-govuk/components/decorated/date-input/macro.njk
@@ -1,0 +1,4 @@
+{% from "govuk/components/date-input/macro.njk" import govukDateInput as source %}
+{% macro govukDateInput(params) %}
+  {{ source(decorate(params, params.decorate)) }}
+{% endmacro %}

--- a/packages/govuk-prototype-components/x-govuk/components/decorated/file-upload/macro.njk
+++ b/packages/govuk-prototype-components/x-govuk/components/decorated/file-upload/macro.njk
@@ -1,0 +1,4 @@
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload as source %}
+{% macro govukFileUpload(params) %}
+  {{ source(decorate(params, params.decorate)) }}
+{% endmacro %}

--- a/packages/govuk-prototype-components/x-govuk/components/decorated/input/macro.njk
+++ b/packages/govuk-prototype-components/x-govuk/components/decorated/input/macro.njk
@@ -1,0 +1,4 @@
+{% from "govuk/components/input/macro.njk" import govukInput as source %}
+{% macro govukInput(params) %}
+  {{ source(decorate(params, params.decorate)) }}
+{% endmacro %}

--- a/packages/govuk-prototype-components/x-govuk/components/decorated/radios/macro.njk
+++ b/packages/govuk-prototype-components/x-govuk/components/decorated/radios/macro.njk
@@ -1,0 +1,4 @@
+{% from "govuk/components/radios/macro.njk" import govukRadios as source %}
+{% macro govukRadios(params) %}
+  {{ source(decorate(params, params.decorate)) }}
+{% endmacro %}

--- a/packages/govuk-prototype-components/x-govuk/components/decorated/select/macro.njk
+++ b/packages/govuk-prototype-components/x-govuk/components/decorated/select/macro.njk
@@ -1,0 +1,4 @@
+{% from "govuk/components/select/macro.njk" import govukSelect as source %}
+{% macro govukSelect(params) %}
+  {{ source(decorate(params, params.decorate)) }}
+{% endmacro %}

--- a/packages/govuk-prototype-components/x-govuk/components/decorated/textarea/macro.njk
+++ b/packages/govuk-prototype-components/x-govuk/components/decorated/textarea/macro.njk
@@ -1,0 +1,4 @@
+{% from "govuk/components/textarea/macro.njk" import govukTextarea as source %}
+{% macro govukTextarea(params) %}
+  {{ source(decorate(params, params.decorate)) }}
+{% endmacro %}

--- a/packages/govuk-prototype-rig/docs/using-data/1. form-components.md
+++ b/packages/govuk-prototype-rig/docs/using-data/1. form-components.md
@@ -29,16 +29,17 @@ Radios, checkboxes and select components also need to add a `checked` or `select
 
 ## Decorating forms
 
-The `decorate` function removes this overhead. This adds `name`, `value`, `id` (or `idPrefix`) and `checked`/`selected` attributes to a GOV.UK form component, with values based on where the data is stored.
+The `decorate` attribute removes this overhead. This adds `name`, `value`, `id` (or `idPrefix`) and `checked`/`selected` attributes to a GOV.UK form component, with values based on where the data is stored.
 
 The above example can now be rewritten like this:
 
 ```njk
-{{ govukInput(decorate({
+{{ govukInput({
   label: {
     text: "Email address"
-  }
-}, "account['email-address']")) }}
+  },
+  decorate: "account.email-address"
+}) }}
 ```
 
 This would generate the following HTML:
@@ -59,7 +60,7 @@ Because of the way this component is currently designed, using the `decorate` fu
 We can prevent this from happening by using the `decorate` param for each field. This will pass though any additional options that have been provided in the component, for example `autocomplete`:
 
 ```njk
-{{ govukDateInput(decorate({
+{{ govukDateInput({
   fieldset: {
     legend: {
       text: "When was your passport issued?"
@@ -74,6 +75,7 @@ We can prevent this from happening by using the `decorate` param for each field.
   }, {
     decorate: "year",
     autocomplete: "bday-year"
-  }]
-}, "date-of-issue")) }}
+  }],
+  decorate: "date-of-issue"
+}) }}
 ```

--- a/packages/govuk-prototype-rig/docs/using-data/1. form-components.md
+++ b/packages/govuk-prototype-rig/docs/using-data/1. form-components.md
@@ -6,7 +6,7 @@ tags: Getting started
 
 With session data, you can build complex, data-driven transactions. Yet adding different values to form components can be repetitive, especially if you are using nested values.
 
-For example, to collect a user’s email address, you could write the following:
+To collect a user’s email address, you would normally write:
 
 ```njk
 {{ govukInput({
@@ -15,7 +15,7 @@ For example, to collect a user’s email address, you could write the following:
   },
   id: "email-address",
   name: "account['email-address']"
-  value: "data.account['email-address']"
+  value: data.account['email-address']
 }) }}
 ```
 
@@ -29,9 +29,9 @@ Radios, checkboxes and select components also need to add a `checked` or `select
 
 ## Decorating forms
 
-The `decorate` attribute removes this overhead. This adds `name`, `value`, `id` (or `idPrefix`) and `checked`/`selected` attributes to a GOV.UK form component, with values based on where the data is stored.
+The `decorate` attribute removes this overhead. It adds `name`, `value`, `id` (or `idPrefix`) and `checked`/`selected` attributes to a GOV.UK form component, with values based on where the data is stored.
 
-The above example can now be rewritten like this:
+The above example can be rewritten as:
 
 ```njk
 {{ govukInput({
@@ -53,17 +53,28 @@ This would generate the following HTML:
 
 ### Date inputs
 
-[The date input component](https://design-system.service.gov.uk/components/date-input/) accepts an optional `items` parameter. If no value is provided, day, month and year fields are shown by default, with the `name` value for each item taken from either a specified `namePrefix`, or the default `name` value for each field.
+[The date input component](https://design-system.service.gov.uk/components/date-input/) accepts an optional `items` parameter.
 
-Because of the way this component is currently designed, using the `decorate` function would generate HTML that uses invalid `name` attributes such as `['user']['date-of-birth']-day` or just `day`.
-
-We can prevent this from happening by using the `decorate` param for each field. This will pass though any additional options that have been provided in the component, for example `autocomplete`:
+If no value is given, day, month and year fields are shown by default. This works with the decorate attribute too:
 
 ```njk
 {{ govukDateInput({
   fieldset: {
     legend: {
       text: "When was your passport issued?"
+    }
+  },
+  decorate: "date-of-issue"
+}) }}
+```
+
+If you need custom attributes on the day, month or year inputs you need to use a `decorate` param for each field:
+
+```njk
+{{ govukDateInput({
+  fieldset: {
+    legend: {
+      text: "What is your date of birth?"
     }
   },
   items: [{
@@ -76,6 +87,6 @@ We can prevent this from happening by using the `decorate` param for each field.
     decorate: "year",
     autocomplete: "bday-year"
   }],
-  decorate: "date-of-issue"
+  decorate: "date-of-birth"
 }) }}
 ```

--- a/packages/govuk-prototype-rig/docs/using-data/2. wizard.md
+++ b/packages/govuk-prototype-rig/docs/using-data/2. wizard.md
@@ -201,12 +201,13 @@ An example Nunjucks layout extending the default rig layout:
 {% endblock %}
 
 {% block form %}
-  {{ govukInput(decorate({
+  {{ govukInput({
     label: {
       classes: "govuk-label--l",
       isPageHeading: true,
       text: title
-    }
-  }, ["wizard", "name"])) }}
+    },
+    decorate: ["wizard", "name"]
+  }) }}
 {% endblock %}
 ```

--- a/packages/govuk-prototype-rig/lib/globals/checked.js
+++ b/packages/govuk-prototype-rig/lib/globals/checked.js
@@ -1,0 +1,45 @@
+import _ from 'lodash'
+
+/**
+ * Check if a property value exists.
+ *
+ * Note: You do not need to use this helper if you are using the `decorate`
+ * attribute provided by the govuk-prototype-components package.
+ * It’s provided by the rig to provide compatibility with prototypes built
+ * using the GOV.UK Prototype Kit.
+ *
+ * @see {@link https://govuk-prototype-kit.herokuapp.com/docs/examples/pass-data}
+ *
+ * @param {string} keyPath - Path to key (using dot/bracket notation)
+ * @param {string} value - Value to check
+ * @returns {boolean} Returns `true` if `value` exists, else `false`
+ */
+export function checked (keyPath, value) {
+  keyPath = _.toPath(keyPath)
+
+  const { data } = this.ctx
+  if (!data) {
+    return ''
+  }
+
+  const storedValue = data[keyPath]
+  if (!storedValue) {
+    return ''
+  }
+
+  let checkedValue = ''
+
+  if (Array.isArray(storedValue)) {
+    // Stored value is an array, check it exists in the array
+    if (storedValue.indexOf(value) !== -1) {
+      checkedValue = 'checked'
+    }
+  } else {
+    // Stored value is a simple value, check it matches
+    if (storedValue === value) {
+      checkedValue = 'checked'
+    }
+  }
+
+  return checkedValue
+}

--- a/packages/govuk-prototype-rig/lib/globals/helper.js
+++ b/packages/govuk-prototype-rig/lib/globals/helper.js
@@ -47,9 +47,10 @@ export function checked (keyPath, value) {
  *
  * @param {string} params - Component parameters
  * @param {string} keyPath - Path to key (using dot/bracket notation)
+ * @param {string} [componentName] - Name of component calling decorate
  * @returns {Object} Updated component parameters
  */
-export function decorate (params, keyPath) {
+export function decorate (params, keyPath, componentName) {
   if (typeof keyPath === 'undefined') {
     return params
   }
@@ -75,6 +76,14 @@ export function decorate (params, keyPath) {
   if (params.validate) {
     data.validations = data.validations || {}
     data.validations[params.name] = params.validate
+  }
+
+  if (componentName === 'govukDateInput' && !params.items) {
+    params.items = [
+      { decorate: 'day' },
+      { decorate: 'month' },
+      { decorate: 'year' }
+    ]
   }
 
   if (params.items) {

--- a/packages/govuk-prototype-rig/lib/globals/helper.js
+++ b/packages/govuk-prototype-rig/lib/globals/helper.js
@@ -50,6 +50,10 @@ export function checked (keyPath, value) {
  * @returns {Object} Updated component parameters
  */
 export function decorate (params, keyPath) {
+  if (typeof keyPath === 'undefined') {
+    return params
+  }
+
   keyPath = _.toPath(keyPath)
 
   const { data, errors } = this.ctx

--- a/packages/govuk-prototype-rig/lib/globals/index.js
+++ b/packages/govuk-prototype-rig/lib/globals/index.js
@@ -1,1 +1,7 @@
-export { helperGlobals as globals } from './helper.js'
+import { decorate } from 'govuk-prototype-components/decorate'
+import { checked } from './checked.js'
+
+export const globals = {
+  checked,
+  decorate
+}

--- a/packages/govuk-prototype-rig/views/feature-flags.njk
+++ b/packages/govuk-prototype-rig/views/feature-flags.njk
@@ -21,7 +21,7 @@
         <h1 class="govuk-heading-l">{{ title }}</h1>
 
         {% for key, flag in data.features %}
-          {{ govukRadios(decorate({
+          {{ govukRadios({
             classes: "govuk-radios--inline",
             fieldset: {
               legend: {
@@ -38,8 +38,9 @@
             }, {
               text: "Off",
               value: false
-            }]
-          }, ["features", key, "on"])) }}
+            }],
+            decorate: ["features", key, "on"]
+          }) }}
         {% else %}
           <p>Create a feature flag by adding an object to the <code>features</code> property in the default session data file:</p>
           <pre class="govuk-!-font-size-19">{{ preCode }}</pre>

--- a/packages/govuk-prototype-rig/views/template.njk
+++ b/packages/govuk-prototype-rig/views/template.njk
@@ -7,30 +7,31 @@
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
-{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
-{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
-{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
-{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-{% from "x-govuk/components/autocomplete/macro.njk" import xGovukAutocomplete %}
+{% from "x-govuk/components/decorated/checkboxes/macro.njk" import govukCheckboxes with context %}
+{% from "x-govuk/components/decorated/date-input/macro.njk" import govukDateInput with context %}
+{% from "x-govuk/components/decorated/file-upload/macro.njk" import govukFileUpload with context %}
+{% from "x-govuk/components/decorated/input/macro.njk" import govukInput with context %}
+{% from "x-govuk/components/decorated/radios/macro.njk" import govukRadios with context %}
+{% from "x-govuk/components/decorated/select/macro.njk" import govukSelect with context %}
+{% from "x-govuk/components/decorated/textarea/macro.njk" import govukTextarea with context %}
+
+{% from "x-govuk/components/autocomplete/macro.njk" import xGovukAutocomplete with context %}
 {% from "x-govuk/components/masthead/macro.njk" import xGovukMasthead %}
 {% from "x-govuk/components/related-navigation/macro.njk" import xGovukRelatedNavigation %}
 {% from "x-govuk/components/side-navigation/macro.njk" import xGovukSideNavigation %}


### PR DESCRIPTION
Add a `decorate: 'name'` parameter to any of the GOVUK form components to automatically decorate them, without having to use the more fiddly function syntax.

## Before

```
{{ govukInput(decorate({
  label: {
    text: "First name"
  }
}, 'first-name')) }}
```

## After

```
{{ govukInput({
  decorate: 'first-name',
  label: {
    text: "First name"
  }
}) }}
```

To do:

- [x] Make date-input items work automatically
- [x] Update examples that use decorate
- [x] Update decorate guidance