### PR TITLE
Add missing lodash dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9077,7 +9077,8 @@
       "dependencies": {
         "accessible-autocomplete": "^2.0.4",
         "ftdomdelegate": "^5.0.0",
-        "govuk-frontend": "^4.0.1"
+        "govuk-frontend": "^4.0.1",
+        "lodash": "^4.17.21"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -12002,7 +12003,8 @@
       "requires": {
         "accessible-autocomplete": "^2.0.4",
         "ftdomdelegate": "^5.0.0",
-        "govuk-frontend": "^4.0.1"
+        "govuk-frontend": "^4.0.1",
+        "lodash": "^4.17.21"
       }
     },
     "govuk-prototype-rig": {

--- a/packages/govuk-prototype-components/package.json
+++ b/packages/govuk-prototype-components/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "accessible-autocomplete": "^2.0.4",
     "ftdomdelegate": "^5.0.0",
-    "govuk-frontend": "^4.0.1"
+    "govuk-frontend": "^4.0.1",
+    "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
`decorate` uses lodash and decorate is now part of this component