### PR TITLE
Fixes to validation

### DIFF
--- a/app/views/examples/validation-error.html
+++ b/app/views/examples/validation-error.html
@@ -1,0 +1,30 @@
+{% extends "layouts/default.html" %}
+{% set title = "Help users to recover from validation errors" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post" novalidate data-validate>
+        {{ govukInput({
+          label: {
+            text: "Full name",
+            isPageHeading: true,
+            classes: "govuk-label--xl"
+          },
+          autocomplete: "name",
+          spellcheck: false,
+          decorate: ["account", "full-name"],
+          validate: {
+            presence: {
+              message: "Enter your full name"
+            }
+          }
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/examples/validation-error.html
+++ b/app/views/examples/validation-error.html
@@ -1,4 +1,5 @@
 {% extends "layouts/default.html" %}
+
 {% set title = "Help users to recover from validation errors" %}
 
 {% block content %}

--- a/packages/govuk-prototype-rig/lib/form-validation.js
+++ b/packages/govuk-prototype-rig/lib/form-validation.js
@@ -237,7 +237,7 @@ function showErrorSummary (errors) {
 
   // Place focus on the error summary
   const newErrorSummary = document.querySelector('.govuk-error-summary')
-  newErrorSummary.focus()
+  new window.GOVUKFrontend.ErrorSummary(newErrorSummary).init()
 }
 
 forms.forEach(form => {

--- a/packages/govuk-prototype-rig/lib/form-validation.js
+++ b/packages/govuk-prototype-rig/lib/form-validation.js
@@ -232,8 +232,8 @@ function showErrorSummary (errors) {
     }
   }
 
-  // Insert error summary above the page title
-  document.querySelector('h1').before(govukErrorSummary)
+  // Insert error summary at the top of the page
+  document.querySelector('main').prepend(govukErrorSummary)
 
   // Place focus on the error summary
   const newErrorSummary = document.querySelector('.govuk-error-summary')

--- a/packages/govuk-prototype-rig/views/template.njk
+++ b/packages/govuk-prototype-rig/views/template.njk
@@ -90,9 +90,13 @@
 {% block bodyEnd %}
   {%- if data.validations %}
   <template id="govuk-error-summary-template">
-    {{ govukErrorSummary({
-      titleText: "There is a problem"
-    }) | indent(4) }}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {{ govukErrorSummary({
+          titleText: "There is a problem"
+        }) | indent(4) }}
+      </div>
+    </div>
   </template>
   <template id="govuk-error-message-template">
     {{ govukErrorMessage() | indent(4) }}


### PR DESCRIPTION
- Use GOVUKFrontend.ErrorSummary to focus the error summary component
- Insert the error summary just inside the main element
- Include an example of validation where the h1 is within the form

## Focus fix

`.focus()` isn't enough, we need to use the ErrorSummary js to also append a tabindex attribute beforehand.

See: https://github.com/alphagov/govuk-frontend/blob/974482f96dfb1c2cdf732e70272f233190ef9839/src/govuk/components/error-summary/error-summary.js

## h1 within form fix

| Before | After |
|--|--|
| ![Screenshot 2022-03-03 at 16 33 40](https://user-images.githubusercontent.com/319055/156615104-df0cf20b-aae3-4951-a0d3-aadd287d3628.png) | ![Screenshot 2022-03-03 at 17 09 04](https://user-images.githubusercontent.com/319055/156615196-2c2e959b-4849-41d1-994e-4120c9c38607.png) |

