### PR TITLE
Default to using HTTPS

### DIFF
--- a/packages/govuk-prototype-rig/lib/config.js
+++ b/packages/govuk-prototype-rig/lib/config.js
@@ -10,7 +10,7 @@ const defaultConfig = {
   useAuth: false,
   useAutoStoreData: true,
   useCookieSessionStore: false,
-  useHttps: false
+  useHttps: true
 }
 
 /**


### PR DESCRIPTION
Users can be inputting sensitive data into prototypes, this should always be over https.