### PR TITLE
Add an early return if there are no errors

### DIFF
--- a/packages/govuk-prototype-rig/lib/form-validation.js
+++ b/packages/govuk-prototype-rig/lib/form-validation.js
@@ -80,6 +80,7 @@ function getSubmitHandler (form) {
     if (!errors) {
       form.removeEventListener('submit', submitHandler)
       form.submit()
+      return
     }
 
     // Remove previous error messages and summary


### PR DESCRIPTION
Without this return, there can be a flash of DOM changes before the next page loads – this is jarring. If we’re submitting the form we don't need to manipulate the DOM.

## Before

https://user-images.githubusercontent.com/319055/157657374-f42b1f14-6a23-4376-a7aa-52e8714503d3.mov

## After

https://user-images.githubusercontent.com/319055/157657566-9e752157-fa48-4edc-9251-23fbbce849ee.mov


